### PR TITLE
Keep releases as drafts until assets are ready

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          draft: false
+          draft: true
           prerelease: false
 
   build:


### PR DESCRIPTION
# Implementation: create draft releases first

## Connections
- **Related Issue:** Closes #17

## Summary of Changes

This PR changes the release workflow so tagged releases are created as drafts first instead of being published immediately.

- creates new releases as drafts while assets are still uploading
- prevents partially built releases from becoming visible too early
- avoids interference with installer flows that resolve through the latest stable release

## Alternatives Considered

- **Leave releases public from the start:** rejected because incomplete releases can become visible before assets exist and interfere with latest-based installer flows.
- **Use prereleases first:** workable, but rejected because the preferred owner workflow is to keep releases hidden entirely until artifacts are ready.
- **Create drafts first and publish manually:** chosen because it keeps the release invisible until validation is complete while preserving the existing asset-upload workflow.

## How to Test

1. Inspect `.github/workflows/release.yml`.
2. Confirm the release creation step now uses:
   ```yaml
   draft: true
   prerelease: false
   ```
3. On the next tag push, verify the workflow creates a draft release first, uploads assets, and leaves final publication as a manual maintainer step.

## Definition of Done (DoD)

- [x] Release workflow creates draft releases first
- [x] Releases are no longer published before assets finish uploading
- [x] Owner can publish the release manually after validation
- [x] Change is scoped to release visibility behavior only

## Technical Notes

- This is an operational workaround to reduce coupling between release timing and latest-based installer flows.
- The deeper medium-term follow-up is still to revisit the installer test's dependency on mutable release resolution.